### PR TITLE
Add GitHub Action to run tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,19 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox:
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox tox_pyo3
+      - run: tox -e py

--- a/tox_pyo3/plugin.py
+++ b/tox_pyo3/plugin.py
@@ -13,7 +13,7 @@ log = logging.getLogger('pyo3')
 
 
 @hookimpl
-def tox_addoption(parser):
+def tox_add_option(parser):
     parser.add_testenv_attribute("pyo3",
                                  "bool",
                                  "Build PyO3 Rust extension",


### PR DESCRIPTION
Fixes #4 

Tox tests are failing at https://github.com/cclauss/tox-pyo3/actions
>  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/pluggy/_manager.py", line 370, in check_pending
    raise PluginValidationError(
pluggy._manager.PluginValidationError: unknown hook 'tox_addoption' in plugin <module 'tox_pyo3.plugin' from '/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/tox_pyo3/plugin.py'>
---
`tox_addoption()` --> `tox_add_option()`
* https://tox.wiki/en/4.11.4/plugins.html#migration-from-tox-3
* https://tox.wiki/en/4.11.4/plugins.html#tox.plugin.spec.tox_add_option
