### PR TITLE
tox.yml: Do not install self from PyPI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install --upgrade pip
-      - run: pip install tox tox_pyo3
+      - run: pip install tox
       - run: tox -e py


### PR DESCRIPTION
Let's test the current code from the current branch of this repo instead of the previously released code on PyPI.
* https://pypi.org/project/tox-pyo3